### PR TITLE
Implement CODE_OF_CONDUCT.md and link in README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+Examples of behavior that contributes to creating a positive environment include:
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Scope
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Reporting
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at **[INSERT YOUR EMAIL]**. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][version]
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/README.md
+++ b/README.md
@@ -96,4 +96,8 @@ Contributions are welcome during the competition period! Please see `CONTRIBUTIN
 This version of the project is released under the **MIT License**. Future proprietary versions will be subject to different commercial licensing terms.
 
 ---
+
+**Community Standards:** Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
+
+---
 *Created for [Apertre 3.0](https://apertre.resourcio.in) Feb - Mar 2026.*


### PR DESCRIPTION
## Description:
This PR addresses the assigned issue #2  by establishing a professional standard for behavior within the Lead Gen Tool community.

## Changes:
1. Created `CODE_OF_CONDUCT.md` based on the Contributor Covenant v2.1.
2. Updated the `README.md` footer to include a direct link to the community standards.
3. Established a reporting protocol for maintainers to ensure a safe environment for all contributors.

## Checklist:
- [x] Code of Conduct added.
- [x] README footer updated with link.
- [x] Closes #2 